### PR TITLE
Install nessaary module in addon

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -58,7 +58,7 @@ bl_info = {
     "name": "BlenderPhotonics_mcx",
     "author": "(c) 2021 Yuxuan (Victor) Zhang, (c) 2021 Qianqian Fang",
     "version": (1, 0),  # min plug-in version
-    "blender": (2, 82, 0),  # min blender version
+    "blender": (3, 5, 0),  # min blender version
     "location": "Layout，UI",
     "description": "An integrated 3D mesh generation and Monte Carlo photon transport simulation environment",
     "warning": "This plug-in requires the preinstallation of Iso2Mesh (http://iso2mesh.sf.net) and MMCLAB (http://mcx.space)",

--- a/__init__.py
+++ b/__init__.py
@@ -75,9 +75,12 @@ from .runmmc import runmmc
 from .niifile import niifile
 from .nii2mesh import nii2mesh
 from bpy.props import PointerProperty
+from .pkg import InstallJData, InstallOct2py
 
 def register():
     print("Registering BlenderPhotonics_mcx")
+    bpy.utils.register_class(InstallOct2py)
+    bpy.utils.register_class(InstallJData)
     bpy.utils.register_class(scene2mesh)
     bpy.utils.register_class(object2surf)
     bpy.utils.register_class(niifile)
@@ -90,6 +93,8 @@ def register():
 
 def unregister():
     print("Unregistering BlenderPhotonics_mcx")
+    bpy.utils.unregister_class(InstallOct2py)
+    bpy.utils.unregister_class(InstallJData)
     bpy.utils.unregister_class(scene2mesh)
     bpy.utils.unregister_class(object2surf)
     bpy.utils.unregister_class(niifile)

--- a/blender2mesh.py
+++ b/blender2mesh.py
@@ -23,7 +23,6 @@ To cite this work, please use the below information
 
 import bpy
 import numpy as np
-import jdata as jd
 import os
 from bpy.utils import register_class, unregister_class
 from .utils import *
@@ -74,6 +73,8 @@ class scene2mesh(bpy.types.Operator):
         return hints[properties.endstep]
 
     def func(self):
+        import jdata as jd
+
         outputdir = GetBPWorkFolder();
         if not os.path.isdir(outputdir):
             os.makedirs(outputdir)

--- a/mesh2blender.py
+++ b/mesh2blender.py
@@ -22,8 +22,6 @@ To cite this work, please use the below information
 """
 
 import bpy
-import numpy as np
-import jdata as jd
 import os
 from .utils import *
 
@@ -39,6 +37,7 @@ class mesh2scene(bpy.types.Operator):
     tool: bpy.props.EnumProperty(default=g_volmeshtype, name='visualization mesh type', items=enum_volmeshtype)
     
     def importmesh(self):
+        import jdata as jd
         # folder path for importing .jmsh files
 
         outputdir = GetBPWorkFolder();

--- a/nii2mesh.py
+++ b/nii2mesh.py
@@ -24,7 +24,6 @@ To cite this work, please use the below information
 
 import bpy
 import numpy as np
-import jdata as jd
 import os
 from .utils import *
 
@@ -51,6 +50,8 @@ class nii2mesh(bpy.types.Operator):
     method: bpy.props.EnumProperty(name="Mesh extraction method", items = [('auto','auto','auto'),('cgalmesh','cgalmesh','cgalmesh'), ('cgalsurf','cgalsurf','cgalsurf'), ('simplify','simplify','simplify')])
  
     def vol2mesh(self):
+        import jdata as jd
+
         # Remove last .jmsh file
         outputdir = GetBPWorkFolder()
         if not os.path.isdir(outputdir):

--- a/pkg.py
+++ b/pkg.py
@@ -14,6 +14,8 @@ class InstallOct2py(bpy.types.Operator):
     def execute(self, context):
         # Install Oct2py
         ADDON_DIR = os.path.join(os.path.abspath(pathlib.Path(__file__).resolve().parent.parent), "modules")
+        if not os.path.exists(ADDON_DIR):
+            os.makedirs(ADDON_DIR)
         subprocess.call([sys.executable, "-m", "pip", "install", "oct2py", "--target=" + ADDON_DIR])
         return {"FINISHED"}
 
@@ -27,5 +29,7 @@ class InstallJData(bpy.types.Operator):
     def execute(self, context):
         # Install JData
         ADDON_DIR = os.path.join(os.path.abspath(pathlib.Path(__file__).resolve().parent.parent), "modules")
+        if not os.path.exists(ADDON_DIR):
+            os.makedirs(ADDON_DIR)
         subprocess.call([sys.executable, "-m", "pip", "install", "jdata", "--target=" + ADDON_DIR])
         return {"FINISHED"}

--- a/pkg.py
+++ b/pkg.py
@@ -1,0 +1,31 @@
+import bpy
+import subprocess
+import sys
+import os
+import pathlib
+
+
+class InstallOct2py(bpy.types.Operator):
+    bl_idname = "blenderphotonics.install_oct2py"
+    bl_label = "Install Package"
+    bl_description = "Install Oct2py Python package"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        # Install Oct2py
+        ADDON_DIR = os.path.join(os.path.abspath(pathlib.Path(__file__).resolve().parent.parent), "modules")
+        subprocess.call([sys.executable, "-m", "pip", "install", "oct2py", "--target=" + ADDON_DIR])
+        return {"FINISHED"}
+
+
+class InstallJData(bpy.types.Operator):
+    bl_idname = "blenderphotonics.install_jdata"
+    bl_label = "Install Package"
+    bl_description = "Install JData package"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        # Install JData
+        ADDON_DIR = os.path.join(os.path.abspath(pathlib.Path(__file__).resolve().parent.parent), "modules")
+        subprocess.call([sys.executable, "-m", "pip", "install", "jdata", "--target=" + ADDON_DIR])
+        return {"FINISHED"}

--- a/runmmc.py
+++ b/runmmc.py
@@ -23,7 +23,6 @@ To cite this work, please use the below information
 
 import bpy
 import numpy as np
-import jdata as jd
 import os
 from .utils import *
 
@@ -65,6 +64,8 @@ class runmmc(bpy.types.Operator):
     colormap: bpy.props.StringProperty(default=g_colormap, name="color scheme")
 
     def preparemmc(self):
+        import jdata as jd
+
         ## save optical parameters and source source information
         parameters = [] # mu_a, mu_s, n, g
         cfg = [] # location, direction, photon number, Type,

--- a/ui.py
+++ b/ui.py
@@ -25,7 +25,6 @@ import bpy
 from .blender2mesh import scene2mesh
 from .mesh2blender import mesh2scene
 from .runmmc import runmmc
-from .niifile import niifile
 from .nii2mesh import nii2mesh
 from .obj2surf import object2surf
 

--- a/ui.py
+++ b/ui.py
@@ -27,6 +27,7 @@ from .mesh2blender import mesh2scene
 from .runmmc import runmmc
 from .nii2mesh import nii2mesh
 from .obj2surf import object2surf
+from .pkg import InstallJData, InstallOct2py
 
 class BlenderPhotonics_UI(bpy.types.Panel):
     bl_label = 'BlenderPhotonics_mcx v2022'
@@ -43,6 +44,9 @@ class BlenderPhotonics_UI(bpy.types.Panel):
         layout = self.layout
         scene = context.scene
         bp = scene.blender_photonics
+        rowengine = layout.row()
+        rowengine.operator(InstallOct2py.bl_idname, text="Install Oct2py", icon='FILE_TICK')
+        rowengine.operator(InstallJData.bl_idname, text="Install JData", icon='FILE_TICK')
         rowengine = layout.row()
         rowengine.label(text="Backend:")
         rowengine.prop(bp, "backend", expand=True)

--- a/utils.py
+++ b/utils.py
@@ -27,7 +27,6 @@ import tempfile
 import numpy as np
 import pyopenvdb as vdb
 import copy
-import jdata as jd
 
 def ShowMessageBox(message = "", title = "Message Box", icon = 'INFO'):
 
@@ -188,6 +187,7 @@ def LoadVolMesh(mesh_np, id, path, mode, colormap='jet'):
 
 
 def AddMaterial(id, alpha, r_number=1, colormap_id='jet'):
+    import jdata as jd
     bpy.data.materials.new(name=id)
     color_assert_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets','colormap_assest.json')
     colorlist = jd.load(color_assert_path)['colormap'][colormap_id]


### PR DESCRIPTION
I added two buttons to the top of addon pannel for automatically installing necessary Python modules. Now, `oct2py` or `jdata` are not required before installing the plugin. The installation directory is set by default to the plugin directory. 

Since Blender 3.5 integrates pyopenvdb into its Python, I suggest adjusting the minimum version requirement to 3.5.

The pipline for users to install blenderphotonics is as follows:
1. Install `Blender` and `Octave`.
2. Download `iso2mesh`, compile `mmc` and `mcx`, and add them to the Octave path.
3. Download and install `blenderphotonics`. Before running it for the first time, click on the "install" buttons at the top of the panel. Once installation is complete, it can be used.blender
![Screenshot from 2023-04-21 10-26-35](https://user-images.githubusercontent.com/60581999/233661890-a3679560-63be-4507-a1d9-95880eae36ae.png)
